### PR TITLE
compatability with jupyterhub 1.0.0

### DIFF
--- a/jhub_remote_login/_jhub_remote_auth.py
+++ b/jhub_remote_login/_jhub_remote_auth.py
@@ -322,7 +322,7 @@ class RemoteUserLoginHandler(BaseHandler):
         if raw_user:
             user = self.process_user(raw_user, self)
 
-        self.redirect(self.get_argument("next", user.url))
+        self.redirect(self.get_next_url(user))
 
 
 class RemoteUserAuthenticator(Authenticator):

--- a/jhub_remote_login/_jhub_remote_auth.py
+++ b/jhub_remote_login/_jhub_remote_auth.py
@@ -1,5 +1,5 @@
 from traitlets import Bool, Unicode
-from tornado import web
+from tornado import web, gen
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler
@@ -223,8 +223,8 @@ class RemoteUserLoginHandler(BaseHandler):
             return b64_encryptedMessage.decode("utf-8")
         else:
             return content
-
-    async def get(self):
+    @gen.coroutine
+    def get(self):
 
         raw_user = yield self.get_current_user()
 

--- a/jhub_remote_login/_jhub_remote_auth.py
+++ b/jhub_remote_login/_jhub_remote_auth.py
@@ -226,7 +226,7 @@ class RemoteUserLoginHandler(BaseHandler):
 
     async def get(self):
 
-        raw_user = self.get_current_user()
+        raw_user = yield self.get_current_user()
 
         if raw_user:
             if self.force_new_server and raw_user.running:


### PR DESCRIPTION
In the latest version of JupyterHub get_current_user is now async and throws a runtime warning:
sys:1: RuntimeWarning: coroutine 'BaseHandler.get_current_user' was never awaited

This causes self.redirect(self.get_argument("next", user.url))
To throw attributeError: 'coroutine' object has no attribute 'url'